### PR TITLE
Singleton cairo context

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,34 @@
 {
-  "cmake.configureOnOpen": false
+  "cmake.configureOnOpen": false,
+  "files.associations": {
+    "bit": "cpp",
+    "cctype": "cpp",
+    "cmath": "cpp",
+    "compare": "cpp",
+    "concepts": "cpp",
+    "cstddef": "cpp",
+    "cstdint": "cpp",
+    "cstdio": "cpp",
+    "cstdlib": "cpp",
+    "cstring": "cpp",
+    "cwchar": "cpp",
+    "exception": "cpp",
+    "initializer_list": "cpp",
+    "iosfwd": "cpp",
+    "limits": "cpp",
+    "list": "cpp",
+    "new": "cpp",
+    "string": "cpp",
+    "tuple": "cpp",
+    "type_traits": "cpp",
+    "unordered_map": "cpp",
+    "utility": "cpp",
+    "vector": "cpp",
+    "xhash": "cpp",
+    "xmemory": "cpp",
+    "xstddef": "cpp",
+    "xstring": "cpp",
+    "xtr1common": "cpp",
+    "xutility": "cpp"
+  }
 }

--- a/include/cairo_context.hpp
+++ b/include/cairo_context.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "cairo.hpp"
+#include "window.hpp"
+
+class CairoContext
+{
+public:
+  CairoContext(const CairoContext& context) = delete;
+  CairoContext(CairoContext&& context) = delete;
+  CairoContext operator=(const CairoContext& context) = delete;
+  CairoContext operator=(CairoContext&& context) = delete;
+
+  ~CairoContext();
+
+  /// @brief Creates an instance of CairoContext.
+  static void create_instance();
+
+  /// @brief Gets CairoContext instance.
+  /// @return Returns CairoContext instance.
+  static CairoContext* get_instance();
+
+  /// @brief Deletes CairoContext instance.
+  static void delete_instance();
+
+  /// @brief Initializes cairo's context for window's surface.
+  /// @param window reference to window.
+  void initialize(Window& window);
+
+  /// @brief Gets cairo's context.
+  /// @return Returns pointer to cairo's context.
+  cairo_t* get_context();
+
+  /// @brief Reloads cairo's context,
+  ///        this should be called when window is resized.
+  /// @param window reference to window.
+  void reload_context(Window& window);
+
+private:
+  /// @brief Pointer to cairo's context.
+  cairo_t* _context;
+
+  /// @brief Private constructor
+  CairoContext();
+
+  /// @brief Pointer to CairoContext's instance.
+  static CairoContext* _instance;
+};

--- a/include/cairo_context.hpp
+++ b/include/cairo_context.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <unordered_map>
+#include "../cairo-windows-1.17.2/include/cairo-ft.h"
+#include "../freetype/freetype/freetype.h"
+#include "../freetype/ft2build.h"
 #include "cairo.hpp"
 #include "window.hpp"
 
@@ -36,9 +40,20 @@ public:
   /// @param window reference to window.
   void reload_context(Window& window);
 
+  bool load_font(const std::string& font_name_to_assign,
+                 const std::string& font_file_path);
+
+  bool set_context_font(const std::string& font_name, const uint8 font_size);
+
 private:
   /// @brief Pointer to cairo's context.
   cairo_t* _context;
+
+  /// @brief Instance of freetype library.
+  FT_Library _freetype;
+
+  /// @brief Fonts mapped to its name.
+  std::unordered_map<std::string, cairo_font_face_t*> _font_map;
 
   /// @brief Private constructor
   CairoContext();

--- a/include/window.hpp
+++ b/include/window.hpp
@@ -60,6 +60,14 @@ public:
   ///        this should be called when window is resized.
   void reload_window_surface();
 
+  /// @brief Updates given rectangle portions in window.
+  /// @param rects pointer to SDL_Rect array.
+  /// @param rects_count length of the SDL_Rect array.
+  void update_rects(SDL_Rect* rects, int rects_count);
+
+  /// @brief Updates window surface (i.e swaps the updated window surface).
+  void update();
+
 private:
   /// @brief window width
   uint16 _width;

--- a/include/window.hpp
+++ b/include/window.hpp
@@ -56,13 +56,9 @@ public:
   /// @return returns false if cannot be set (on platforms linux, macos).
   bool set_dark_theme();
 
-  /// @brief Window's cairo context.
-  /// @return Returns pointer to window's cairo context.
-  cairo_t* cairo_context();
-
   /// @brief Reloads the cairo context of window,
   ///        this should be called when window is resized.
-  void reload_cairo_context();
+  void reload_window_surface();
 
 private:
   /// @brief window width
@@ -79,9 +75,6 @@ private:
 
   /// @brief pointer to window's surface
   SDL_Surface* _window_surface;
-
-  /// @brief pointer to cairo context
-  cairo_t* _cairo_context;
 
   friend class CairoContext;
 };

--- a/include/window.hpp
+++ b/include/window.hpp
@@ -43,6 +43,10 @@ public:
   /// @return Returns reference to window title.
   std::string& title();
 
+  /// @brief Window's surface.
+  /// @return Returns pointer to window's surface.
+  SDL_Surface* surface();
+
   /// @brief Sets window icon in windows and linux, icon should be BMP format.
   /// @param icon_path icon file path.
   /// @return returns false if icon cannot be found at given path.
@@ -78,4 +82,6 @@ private:
 
   /// @brief pointer to cairo context
   cairo_t* _cairo_context;
+
+  friend class CairoContext;
 };

--- a/src/cairo_context.cpp
+++ b/src/cairo_context.cpp
@@ -1,0 +1,65 @@
+#include "../include/cairo_context.hpp"
+#include "../include/macros.hpp"
+
+CairoContext* CairoContext::_instance = nullptr;
+
+CairoContext::CairoContext() {}
+
+CairoContext::~CairoContext()
+{
+  cairo_destroy(_context);
+}
+
+void CairoContext::create_instance()
+{
+  if(_instance)
+  {
+    ERROR_BOII(
+      "CairoContext is already instantiated, use CairoContext::get_instance()");
+    return;
+  }
+
+  _instance = new CairoContext();
+}
+
+CairoContext* CairoContext::get_instance()
+{
+  return _instance;
+}
+
+void CairoContext::delete_instance()
+{
+  delete _instance;
+}
+
+void CairoContext::initialize(Window& window)
+{
+  SDL_Surface* window_surface = window.surface();
+  cairo_surface_t* cairo_surface =
+    cairo_image_surface_create_for_data((unsigned char*)window_surface->pixels,
+                                        CAIRO_FORMAT_RGB24,
+                                        window_surface->w,
+                                        window_surface->h,
+                                        window_surface->pitch);
+  _context = cairo_create(cairo_surface);
+  cairo_surface_destroy(cairo_surface);
+}
+
+cairo_t* CairoContext::get_context()
+{
+  return _context;
+}
+
+void CairoContext::reload_context(Window& window)
+{
+  SDL_Surface* window_surface = window.surface();
+  cairo_destroy(_context);
+  cairo_surface_t* cairo_surface =
+    cairo_image_surface_create_for_data((unsigned char*)window_surface->pixels,
+                                        CAIRO_FORMAT_RGB24,
+                                        window_surface->w,
+                                        window_surface->h,
+                                        window_surface->pitch);
+  _context = cairo_create(cairo_surface);
+  cairo_surface_destroy(cairo_surface);
+}

--- a/src/cairo_context.cpp
+++ b/src/cairo_context.cpp
@@ -7,6 +7,11 @@ CairoContext::CairoContext() {}
 
 CairoContext::~CairoContext()
 {
+  // Destroying font faces
+  for(auto it = _font_map.begin(); it != _font_map.end(); it++)
+  {
+    cairo_font_face_destroy((*it).second);
+  }
   cairo_destroy(_context);
 }
 
@@ -41,8 +46,15 @@ void CairoContext::initialize(Window& window)
                                         window_surface->w,
                                         window_surface->h,
                                         window_surface->pitch);
+  cairo_surface_set_device_scale(cairo_surface, 1, 1);
   _context = cairo_create(cairo_surface);
   cairo_surface_destroy(cairo_surface);
+
+  int error = 0;
+  if((error = FT_Init_FreeType(&_freetype)))
+  {
+    ERROR_BOII("Unable to initialize freetype: %d", error);
+  }
 }
 
 cairo_t* CairoContext::get_context()
@@ -60,6 +72,41 @@ void CairoContext::reload_context(Window& window)
                                         window_surface->w,
                                         window_surface->h,
                                         window_surface->pitch);
+  cairo_surface_set_device_scale(cairo_surface, 1, 1);
   _context = cairo_create(cairo_surface);
   cairo_surface_destroy(cairo_surface);
+}
+
+bool CairoContext::load_font(const std::string& font_name_to_assign,
+                             const std::string& font_file_path)
+{
+  FT_Face font;
+  int error = 0;
+  if((error = FT_New_Face(_freetype, font_file_path.c_str(), 0, &font)))
+  {
+    ERROR_BOII(
+      "Unable to load font: %s, error code: %d", font_file_path.c_str(), error);
+    return false;
+  }
+
+  cairo_font_face_t* ct = cairo_ft_font_face_create_for_ft_face(font, 0);
+  _font_map.insert(std::make_pair(font_name_to_assign, ct));
+  return true;
+}
+
+bool CairoContext::set_context_font(const std::string& font_name,
+                                    const uint8 font_size)
+{
+  std::unordered_map<std::string, cairo_font_face_t*>::iterator it =
+    _font_map.find(font_name);
+  if(it == _font_map.end())
+  {
+    ERROR_BOII("Unable to set context font: %s, maybe it wasn't loaded!",
+               font_name.c_str());
+    return false;
+  }
+
+  cairo_set_font_face(_context, (*it).second);
+  cairo_set_font_size(_context, font_size);
+  return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,13 +40,40 @@ int main(int argc, char** argv)
       }
       if(event.type == SDL_WINDOWEVENT)
       {
-        if(event.window.type == SDL_WINDOWEVENT_RESIZED)
+        if(event.window.event == SDL_WINDOWEVENT_RESIZED)
         {
           window->reload_window_surface();
           CairoContext::get_instance()->reload_context(*window);
         }
       }
     }
+
+    // Rendering
+    double xc = 220.0;
+    double yc = 240.0;
+    double radius = 200.0;
+    double angle1 = 45.0 * (M_PI / 180.0);
+    double angle2 = 180.0 * (M_PI / 180.0);
+
+    cairo_t* cr = CairoContext::get_instance()->get_context();
+    cairo_set_source_rgba(cr, 0, 0, 0, 1.0);
+    cairo_set_line_width(cr, 10.0);
+    cairo_arc(cr, xc, yc, radius, angle1, angle2);
+    cairo_stroke(cr);
+
+    cairo_set_source_rgba(cr, 1, 0.2, 0.2, 0.6);
+    cairo_set_line_width(cr, 6.0);
+
+    cairo_arc(cr, xc, yc, 10.0, 0, 2 * M_PI);
+    cairo_fill(cr);
+
+    cairo_arc(cr, xc, yc, radius, angle1, angle1);
+    cairo_line_to(cr, xc, yc);
+    cairo_arc(cr, xc, yc, radius, angle2, angle2);
+    cairo_line_to(cr, xc, yc);
+    cairo_stroke(cr);
+
+    window->update();
   }
 
   CairoContext::delete_instance();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,14 @@ int main(int argc, char** argv)
   CairoContext::create_instance();
   CairoContext::get_instance()->initialize(*window);
 
+  // Loading font
+  CairoContext::get_instance()->load_font(
+    "JetBrainsMono",
+    "assets/fonts/JetBrains Mono Regular Nerd Font Complete.ttf");
+  CairoContext::get_instance()->set_context_font("JetBrainsMono", 18);
+
   // main loop
+  bool redraw = true;
   while(1)
   {
     SDL_Event event;
@@ -44,8 +51,14 @@ int main(int argc, char** argv)
         {
           window->reload_window_surface();
           CairoContext::get_instance()->reload_context(*window);
+          redraw = true;
         }
       }
+    }
+
+    if(!redraw)
+    {
+      continue;
     }
 
     // Rendering
@@ -73,7 +86,21 @@ int main(int argc, char** argv)
     cairo_line_to(cr, xc, yc);
     cairo_stroke(cr);
 
+    cairo_close_path(cr);
+
+    // Rendering text
+    const char text[] = "Hola!";
+    // cairo_text_extents_t text_extents;
+    // cairo_text_extents(cr, text, &text_extents);
+    cairo_move_to(cr, 500, 500);
+    // cairo_move_to(cr, 50, 50 + text_extents.height);
+    cairo_set_source_rgb(cr, 0, 0, 0);
+    CairoContext::get_instance()->set_context_font("JetBrainsMono", 18);
+    cairo_show_text(cr, text);
+
     window->update();
+
+    redraw = false;
   }
 
   CairoContext::delete_instance();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "../include/cairo_context.hpp"
 #include "../include/macros.hpp"
 #include "../include/sdl2.hpp"
 #include "../include/window.hpp"
@@ -16,11 +17,15 @@ int main(int argc, char** argv)
   SDL_GetCurrentDisplayMode(0, &display_mode);
 
   // Creating window
-  Window window("Text Editor - Software Rendering",
-                0.8 * display_mode.w,
-                0.8 * display_mode.h);
-  window.set_icon("assets/images/rocket.bmp");
-  window.set_dark_theme();
+  Window* window = new Window("Text Editor - Software Rendering",
+                              0.8 * display_mode.w,
+                              0.8 * display_mode.h);
+  window->set_icon("assets/images/rocket.bmp");
+  window->set_dark_theme();
+
+  // Creating cairo context
+  CairoContext::create_instance();
+  CairoContext::get_instance()->initialize(*window);
 
   // main loop
   while(1)
@@ -33,9 +38,19 @@ int main(int argc, char** argv)
         SDL_Quit();
         return 0;
       }
+      if(event.type == SDL_WINDOWEVENT)
+      {
+        if(event.window.type == SDL_WINDOWEVENT_RESIZED)
+        {
+          window->reload_window_surface();
+          CairoContext::get_instance()->reload_context(*window);
+        }
+      }
     }
   }
 
+  CairoContext::delete_instance();
+  delete window;
   SDL_Quit();
 
   return 0;

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -100,6 +100,11 @@ std::string& Window::title()
   return _title;
 }
 
+SDL_Surface* Window::surface()
+{
+  return _window_surface;
+}
+
 bool Window::set_icon(const char* icon_path)
 {
   SDL_Surface* rocket_icon = SDL_LoadBMP(icon_path);

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -137,3 +137,13 @@ void Window::reload_window_surface()
     FATAL_BOII("Unable to reload window surface: %s", SDL_GetError());
   }
 }
+
+void Window::update_rects(SDL_Rect* rects, int rects_count)
+{
+  SDL_UpdateWindowSurfaceRects(_window, rects, rects_count);
+}
+
+void Window::update()
+{
+  SDL_UpdateWindowSurface(_window);
+}

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -12,7 +12,6 @@ Window::Window(const std::string& title,
   , _height(height)
   , _window(nullptr)
   , _window_surface(nullptr)
-  , _cairo_context(nullptr)
 {
   _window = SDL_CreateWindow(_title.c_str(),
                              SDL_WINDOWPOS_CENTERED,
@@ -36,37 +35,10 @@ Window::Window(const std::string& title,
     SDL_Quit();
     exit(1);
   }
-
-  cairo_surface_t* cairo_surface =
-    cairo_image_surface_create_for_data((unsigned char*)_window_surface->pixels,
-                                        CAIRO_FORMAT_RGB24,
-                                        _window_surface->w,
-                                        _window_surface->h,
-                                        _window_surface->pitch);
-  if(!cairo_surface)
-  {
-    FATAL_BOII("Unable to create cairo surface for window!");
-    SDL_DestroyWindow(_window);
-    SDL_Quit();
-    exit(1);
-  }
-  cairo_surface_set_device_scale(cairo_surface, 1, 1);
-
-  _cairo_context = cairo_create(cairo_surface);
-  if(!_cairo_context)
-  {
-    FATAL_BOII("Unable to create cairo context for window!");
-    cairo_surface_destroy(cairo_surface);
-    SDL_DestroyWindow(_window);
-    SDL_Quit();
-    exit(1);
-  }
-  cairo_surface_destroy(cairo_surface);
 }
 
 Window::~Window()
 {
-  cairo_destroy(_cairo_context);
   SDL_DestroyWindow(_window);
 }
 
@@ -157,28 +129,11 @@ bool Window::set_dark_theme()
   return false;
 }
 
-cairo_t* Window::cairo_context()
-{
-  return _cairo_context;
-}
-
-void Window::reload_cairo_context()
+void Window::reload_window_surface()
 {
   _window_surface = SDL_GetWindowSurface(_window);
   if(!_window_surface)
   {
     FATAL_BOII("Unable to reload window surface: %s", SDL_GetError());
   }
-
-  cairo_destroy(_cairo_context);
-  cairo_surface_t* cairo_surface =
-    cairo_image_surface_create_for_data((unsigned char*)_window_surface->pixels,
-                                        CAIRO_FORMAT_RGB24,
-                                        _window_surface->w,
-                                        _window_surface->h,
-                                        _window_surface->pitch);
-  cairo_surface_set_device_scale(cairo_surface, 1, 1);
-
-  _cairo_context = cairo_create(cairo_surface);
-  cairo_surface_destroy(cairo_surface);
 }

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -35,6 +35,10 @@ Window::Window(const std::string& title,
     SDL_Quit();
     exit(1);
   }
+
+  // White background
+  SDL_FillRect(
+    _window_surface, NULL, SDL_MapRGB(_window_surface->format, 255, 255, 255));
 }
 
 Window::~Window()
@@ -136,6 +140,8 @@ void Window::reload_window_surface()
   {
     FATAL_BOII("Unable to reload window surface: %s", SDL_GetError());
   }
+  SDL_FillRect(
+    _window_surface, NULL, SDL_MapRGB(_window_surface->format, 255, 255, 255));
 }
 
 void Window::update_rects(SDL_Rect* rects, int rects_count)


### PR DESCRIPTION
Moved cairo's context from window class to a seperate singleton class, as it is required for all drawing operations.